### PR TITLE
Fixes #21: Unkown entries causing schema errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/${TRAVIS_REPO_SLUG}
   matrix:
   - TEST_TYPE=build
+  - TEST_TYPE=small
 matrix:
   exclude:
   - go: 1.6.3

--- a/apache/metrics.go
+++ b/apache/metrics.go
@@ -136,6 +136,7 @@ func NewStatus(metricMap map[string][]string) (Status, error) {
 		ServerUptime:  "Not Found",
 	}
 	decoder := schema.NewDecoder()
+	decoder.IgnoreUnknownKeys(true)
 	err := decoder.Decode(status, metricMap)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	pluginName    = "apache"
-	pluginVersion = 3
+	pluginVersion = 4
 )
 
 func main() {


### PR DESCRIPTION
Summary of changes:
Sets IgnoreUnknown keys on the schema decoder to true so that we ignore
unknown keys instead of erroring on them.

How to verify it:
- Point at an apache mod_status url with SSLSessionCache entries and verify that it fails to collect against this url prior to this PR and succeeds after. See #21 for details.

Testing done:
- Added an automated test as well as manual testing as described above.

