### PR TITLE
Adds large tests to plugin catalog metadata

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -1,0 +1,11 @@
+name: apache
+type: collector
+maintainer: core
+license: Apache-2.0
+description: "Collects Apache webserver mod_status metrics"
+badge:
+  - "[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-collector-apache.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-collector-apache)"
+  - "[![Build Status](https://ci.snap-telemetry.io/job/snap-plugin-collector-apache-ec2-periodic/badge/icon)](https://ci.snap-telemetry.io/job/snap-plugin-collector-apache-ec2-periodic/)"
+ci:
+  - https://travis-ci.org/intelsdi-x/snap-plugin-collector-apache
+  - https://ci.snap-telemetry.io/job/snap-plugin-collector-apache-ec2-periodic


### PR DESCRIPTION
This will allow for [plugin sync](https://github.com/intelsdi-x/snap-pluginsync) to add a build status to the plugin catalog similar to what was done manually in intelsdi-x/snap@05da827